### PR TITLE
Fixing build/lint warnings in MKNetworkKit

### DIFF
--- a/MKNetworkKit/MKNetworkOperation.m
+++ b/MKNetworkKit/MKNetworkOperation.m
@@ -1297,7 +1297,10 @@ OSStatus extractIdentityAndTrust(CFDataRef inPKCS12Data,        // 5
           
           [challenge.sender useCredential:[NSURLCredential credentialForTrust:challenge.protectionSpace.serverTrust] forAuthenticationChallenge:challenge];
         }
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
         else if(result == kSecTrustResultConfirm) {
+#pragma clang diagnostic pop
           
           if(self.shouldContinueWithInvalidCertificate) {
             
@@ -1350,7 +1353,10 @@ OSStatus extractIdentityAndTrust(CFDataRef inPKCS12Data,        // 5
   // {
   self.response = (NSHTTPURLResponse*) response;
   const long long sz = [self contentLength];
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wshorten-64-to-32"
   NSUInteger size = sz < 0 ? 0 : sz;
+#pragma clang diagnostic pop
   // }
 //    NSUInteger size = [self.response expectedContentLength] < 0 ? 0 : [self.response expectedContentLength];
   
@@ -1499,7 +1505,7 @@ OSStatus extractIdentityAndTrust(CFDataRef inPKCS12Data,        // 5
 }
 
 - (NSCachedURLResponse *)connection:(NSURLConnection *)connection willCacheResponse:(NSCachedURLResponse *)cachedResponse {
-    return NO;
+    return nil;
 }
 
 - (void)connection:(NSURLConnection *)connection didSendBodyData:(NSInteger)bytesWritten


### PR DESCRIPTION
I don't seem to be able to push to CocoaPods without fixing warnings, so here goes.

NB: The two that I added ignore messages around are areas where I don't want to be in the business of fixing third party libraries that I'm not that familiar with.  The third one (`[NSURLConnectionDataDelegate connection:willCacheResponse:]`) is a straightforward enough bug that I simply fixed.
